### PR TITLE
fix issue #52

### DIFF
--- a/src/data/batch_generator.h
+++ b/src/data/batch_generator.h
@@ -35,7 +35,9 @@ class BatchGenerator {
 
     std::deque<BatchPtr> bufferedBatches_;
     BatchPtr currentBatch_;
-
+    
+    std::mt19937 g_;
+    
     void fillBatches(bool shuffle=true) {
       auto cmp = [](const sample& a, const sample& b) {
         return a[0].size() < b[0].size();
@@ -108,7 +110,7 @@ class BatchGenerator {
         bufferedBatches_.push_back(data_->toBatch(batchVector));
 
       if(shuffle) {
-        std::random_shuffle(bufferedBatches_.begin(), bufferedBatches_.end());
+        std::shuffle(bufferedBatches_.begin(), bufferedBatches_.end(), g_);
       }
     }
 
@@ -118,7 +120,8 @@ class BatchGenerator {
                    Ptr<BatchStats> stats = nullptr)
     : data_(data),
       options_(options),
-      stats_(stats) { }
+      stats_(stats),
+      g_(Config::seed)  { }
 
     operator bool() const {
       return !bufferedBatches_.empty();

--- a/src/data/corpus.cpp
+++ b/src/data/corpus.cpp
@@ -34,14 +34,12 @@ const SentenceTuple& CorpusIterator::dereference() const {
 Corpus::Corpus(Ptr<Config> options, bool translate)
   : options_(options),
     maxLength_(options_->get<size_t>("max-length")),
-    g_(rd_()) {
+    g_(Config::seed) {
 
   if(!translate)
     textPaths_ = options_->get<std::vector<std::string>>("train-sets");
   else
     textPaths_ = options_->get<std::vector<std::string>>("input");
-
-  g_.seed(Config::seed);
 
   std::vector<std::string> vocabPaths;
   if(options_->has("vocabs"))

--- a/src/data/corpus.h
+++ b/src/data/corpus.h
@@ -260,7 +260,6 @@ class Corpus {
     std::vector<Ptr<Vocab>> vocabs_;
     size_t maxLength_;
 
-    std::random_device rd_;
     std::mt19937 g_;
     std::vector<size_t> ids_;
     size_t pos_{0};


### PR DESCRIPTION
Running with seed 321 on 1 GPU, produced exactly the same loss
 Run 1:
````
[2017-05-19 17:43:31] Ep. 1 : Up. 10 : Sen. 800 : Cost 265.20 : Time 45.13s : 489.39 words/s
[2017-05-19 17:43:42] Ep. 1 : Up. 20 : Sen. 1600 : Cost 214.16 : Time 10.60s : 1707.03 words/s
[2017-05-19 17:43:55] Ep. 1 : Up. 30 : Sen. 2400 : Cost 261.21 : Time 13.52s : 1761.30 words/s
[2017-05-19 17:44:07] Ep. 1 : Up. 40 : Sen. 3200 : Cost 212.64 : Time 11.56s : 1755.03 words/s
[2017-05-19 17:44:17] Ep. 1 : Up. 50 : Sen. 4000 : Cost 175.44 : Time 10.52s : 1666.84 words/s
[2017-05-19 17:44:29] Ep. 1 : Up. 60 : Sen. 4800 : Cost 194.40 : Time 12.12s : 1678.90 words/s
[2017-05-19 17:44:40] Ep. 1 : Up. 70 : Sen. 5600 : Cost 174.62 : Time 11.04s : 1724.92 words/s
[2017-05-19 17:44:51] Ep. 1 : Up. 80 : Sen. 6400 : Cost 160.17 : Time 10.72s : 1688.02 words/s
[2017-05-19 17:45:03] Ep. 1 : Up. 90 : Sen. 7200 : Cost 182.06 : Time 12.25s : 1723.48 words/s
[2017-05-19 17:45:14] Ep. 1 : Up. 100 : Sen. 8000 : Cost 156.26 : Time 10.82s : 1690.31 words/s
[2017-05-19 17:45:20] [valid] 100 : cross-entropy : 171.635 : new best
[2017-05-19 17:45:38] Ep. 1 : Up. 110 : Sen. 8800 : Cost 167.47 : Time 23.90s : 842.37 words/s
[2017-05-19 17:45:47] Ep. 1 : Up. 120 : Sen. 9600 : Cost 130.82 : Time 9.03s : 1751.07 words/s
[2017-05-19 17:46:00] Ep. 1 : Up. 130 : Sen. 10400 : Cost 184.10 : Time 13.07s : 1732.60 words/s
[2017-05-19 17:46:11] Ep. 1 : Up. 140 : Sen. 11200 : Cost 157.19 : Time 11.11s : 1729.68 words/s
[2017-05-19 17:46:22] Ep. 1 : Up. 150 : Sen. 12000 : Cost 146.22 : Time 10.35s : 1737.79 words/s
```

Run 2:
```
[2017-05-19 17:47:13] Ep. 1 : Up. 10 : Sen. 800 : Cost 265.20 : Time 41.98s : 526.12 words/s
[2017-05-19 17:47:23] Ep. 1 : Up. 20 : Sen. 1600 : Cost 214.16 : Time 10.58s : 1710.65 words/s
[2017-05-19 17:47:37] Ep. 1 : Up. 30 : Sen. 2400 : Cost 261.21 : Time 13.55s : 1756.76 words/s
[2017-05-19 17:47:49] Ep. 1 : Up. 40 : Sen. 3200 : Cost 212.64 : Time 11.51s : 1762.74 words/s
[2017-05-19 17:47:59] Ep. 1 : Up. 50 : Sen. 4000 : Cost 175.44 : Time 10.35s : 1693.37 words/s
[2017-05-19 17:48:11] Ep. 1 : Up. 60 : Sen. 4800 : Cost 194.40 : Time 12.17s : 1671.96 words/s
[2017-05-19 17:48:22] Ep. 1 : Up. 70 : Sen. 5600 : Cost 174.62 : Time 11.13s : 1710.88 words/s
[2017-05-19 17:48:33] Ep. 1 : Up. 80 : Sen. 6400 : Cost 160.17 : Time 10.59s : 1708.70 words/s
[2017-05-19 17:48:45] Ep. 1 : Up. 90 : Sen. 7200 : Cost 182.06 : Time 12.10s : 1745.72 words/s
[2017-05-19 17:48:56] Ep. 1 : Up. 100 : Sen. 8000 : Cost 156.26 : Time 10.98s : 1665.04 words/s
[2017-05-19 17:49:02] [valid] 100 : cross-entropy : 171.635 : new best
[2017-05-19 17:49:21] Ep. 1 : Up. 110 : Sen. 8800 : Cost 167.47 : Time 24.71s : 814.99 words/s
[2017-05-19 17:49:30] Ep. 1 : Up. 120 : Sen. 9600 : Cost 130.82 : Time 9.04s : 1749.12 words/s
[2017-05-19 17:49:43] Ep. 1 : Up. 130 : Sen. 10400 : Cost 184.10 : Time 12.98s : 1744.49 words/s
[2017-05-19 17:49:54] Ep. 1 : Up. 140 : Sen. 11200 : Cost 157.19 : Time 11.20s : 1715.70 words/s
[2017-05-19 17:50:04] Ep. 1 : Up. 150 : Sen. 12000 : Cost 146.22 : Time 10.38s : 1732.79 words/s
```

